### PR TITLE
Fixed missing letter when the files do not have a common prefix.

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -8,9 +8,10 @@ exports.findCommonBase = function(files) {
     for (var i = prefixlen; i > 0; i--) {
       if (file.substr(0,i) === first.substr(0,i)) {
         prefixlen = i;
-        break;
+        return;
       }
     }
+    prefixlen = 0;
   });
   return first.substr(0,prefixlen);
 };


### PR DESCRIPTION
When the files being reported had no common prefix, `util.findCommonBase()` returned the first character of the first path, which resulted in letters missing from any other path.

The bug can be reproduced by running the README’s example command, but within src:

```
cd src
plato -d report *.js
```

This fixes the issue by allowing the prefix to be empty.
