### PR TITLE
allow modal options (-h -v) to ignore -d

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -50,7 +50,8 @@ exports.args = parseArgs(exports.options);
 
 function parseArgs(options) {
   var optionString = '',
-      required = [];
+      required = [],
+      modal = false;
 
   Object.keys(options).forEach(function(option){
     var def = options[option];
@@ -69,15 +70,21 @@ function parseArgs(options) {
     arg.value = option.optarg || true;
 
     args[option.option] = arg;
+
+    if (options[option.option].modal) {
+      modal = true;
+    }
   }
 
-  required.forEach(function(option) {
-    if (!args[option] || !args[option].value) {
-      console.log("Must specify a value for option %s (%s : %s)", option, options[option].long, options[option].desc);
-      info.help();
-      process.exit(1);
-    }
-  });
+  if (!modal) {
+    required.forEach(function(option) {
+      if (!args[option] || !args[option].value) {
+        console.log("Must specify a value for option %s (%s : %s)", option, options[option].long, options[option].desc);
+        info.help();
+        process.exit(1);
+      }
+    });
+  }
 
   // what's left in argv
   args.files = process.argv.slice(parser.optind());

--- a/lib/cli/options.json
+++ b/lib/cli/options.json
@@ -2,12 +2,14 @@
   "h": {
     "long": "help",
     "desc": "Display this help text.",
-    "type": "Boolean"
+    "type": "Boolean",
+    "modal": true
   },
   "v": {
     "long": "version",
     "desc": "Print the version.",
-    "type": "Boolean"
+    "type": "Boolean",
+    "modal": true
   },
   "d": {
     "long": "dir",


### PR DESCRIPTION
fixing a minor annoyance - right now, you can't enter `plato -v` without adding an output directory
