### PR TITLE
Escape HTML for file-source template

### DIFF
--- a/lib/plato.js
+++ b/lib/plato.js
@@ -234,7 +234,7 @@ function writeOverview(outfile, report, options) {
 function writeFileReport(outdir, report, source, options) {
   var overviewSource = fs.readFileSync(fileTemplate).toString();
   var parsed = _.template(overviewSource, {
-    source : source,
+    source : util.escapeHTML(source),
     report : report
   });
   var indexPath = path.join(outdir,'index.html');

--- a/lib/util.js
+++ b/lib/util.js
@@ -53,3 +53,12 @@ exports.stripComments = function (str) {
   return str.replace(multiline, '').replace(singleline, '');
 };
 
+// http://stackoverflow.com/a/4835406/338762
+exports.escapeHTML = function (html) {
+  return html
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;")
+      .replace(/'/g, "&#039;");
+};

--- a/test/util_test.js
+++ b/test/util_test.js
@@ -61,4 +61,11 @@ exports['util'] = {
 
     test.done();
   },
+  'escape HTML': function(test) {
+      test.expect(1);
+
+      test.equal(util.escapeHTML('<div>"test&\'</div>'), '&lt;div&gt;&quot;test&amp;&#039;&lt;/div&gt;', 'should convert HTML tags into HTML special characters');
+
+      test.done();
+  }
 };


### PR DESCRIPTION
Adds escapeHTML util method to be used on writeFileReport in order to prevent the source code to be broken when the JavaScript file contains HTML tags
