### PR TITLE
Display the filename when a parse error occurs.

### DIFF
--- a/lib/plato.js
+++ b/lib/plato.js
@@ -102,7 +102,7 @@ exports.inspect = function(files, outputDir, options, done) {
             report[name] = reporter.process(source, flags[name], report.info);
           } catch(e) {
             error = true;
-            log.error('Error reading file : ', e.toString());
+            log.error('Error reading file %s: ', file, e.toString());
             log.error(e.stack);
           }
         });


### PR DESCRIPTION
I was having a parse error in esprima because my file started with this line:

```
#!/usr/bin/env phantomjs
```

It took me a few minutes to figure out that that was causing it, because the file name was not being reported. I've added the file name to the log call. In the end, it would be nice if we could filter those shebang lines out of the code before analyzing them, but that's for another issue.
