### PR TITLE
Performance: calculate chart width only once

### DIFF
--- a/reports/assets/scripts/plato-overview.js
+++ b/reports/assets/scripts/plato-overview.js
@@ -34,10 +34,11 @@ $(function(){
 
   function drawFileCharts() {
     // @todo make a jQuery plugin to accomodate the horizontalBar function
-    $('.js-file-chart').each(function(){
-      var el = $(this),
-          width = el.width() - 130; // @todo establish max width of graph in plugin
+    var charts = $('.js-file-chart'),
+        width = charts.width() - 130; // @todo establish max width of graph in plugin
 
+    charts.each(function() {
+      var el = $(this);
       el.empty();
 
       var value = el.data('complexity');


### PR DESCRIPTION
For project with 1735 files `drawFileCharts()` in Chrome 33 took ~60s before, and ~20s after that fix.
