### PR TITLE
Performance: deferred chart drawing

### DIFF
--- a/reports/assets/scripts/plato-overview.js
+++ b/reports/assets/scripts/plato-overview.js
@@ -131,10 +131,6 @@ $(function(){
     });
 
     function onGraphClick(i){
-      // If the i is not set, we jump to the last file in the list. This
-      // preserves a behavior from Morris v1. I expect Plato V1 to be deprecated
-      // and this hack is mearly to preserve the casper tests.
-      if (!i || isNaN(i)) { i = __report.reports.length - 1; }
       document.location = __report.reports[i].info.link;
     }
 


### PR DESCRIPTION
Main report page `index.html` is unresponsive (frozen) during loading, because charts are drawn synchronously. This patch makes overview and file chart drawing deferred, allowing page be more responsive during initial load.
