### PR TITLE
pass cli option --quiet through to util.readJSON

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -27,6 +27,7 @@ exports.exec = function(options, done) {
   var outputDir = exports.args.d.value;
   var platoOptions = {
     recurse : !!exports.args.r,
+    q: !!exports.args.q,
     title : exports.args.t && exports.args.t.value,
     exclude : exports.args.x && new RegExp(exports.args.x.value),
     date : exports.args.D && exports.args.D.value

--- a/lib/plato.js
+++ b/lib/plato.js
@@ -199,14 +199,14 @@ exports.getOverviewReport = function (reports) {
 };
 
 function updateHistoricalOverview(outfilePrefix, overview, options) {
-  var existingData = util.readJSON(outfilePrefix + '.history.json') || {};
+  var existingData = util.readJSON(outfilePrefix + '.history.json', options) || {};
   var history = new OverviewHistory(existingData);
   history.addReport(overview, options.date);
   writeReport(outfilePrefix + '.history', history.toJSON(), '__history');
 }
 
 function updateHistoricalReport(outfilePrefix, overview, options) {
-  var existingData = util.readJSON(outfilePrefix + '.history.json') || {};
+  var existingData = util.readJSON(outfilePrefix + '.history.json', options) || {};
   var history = new FileHistory(existingData);
   overview.date = options.date;
   history.addReport(overview, options.date);

--- a/lib/util.js
+++ b/lib/util.js
@@ -31,7 +31,8 @@ exports.formatJSON = function (report) {
   });
 };
 
-exports.readJSON = function (file) {
+exports.readJSON = function (file, options) {
+  if (options.q) log.level = Logger.ERROR;
   var result;
   log.debug('Parsing JSON from file %s', file);
   try {


### PR DESCRIPTION
warning message "Could not parse JSON from file" should be suppressed when --quiet is specified
