### PR TITLE
Update JSHint to the latest version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,6 @@
     "posix-getopt": "~1.0.0",
     "lodash": "~1.0.1",
     "fs-extra": "~0.3.2",
-    "jshint": "~2.1.2"
+    "jshint": "~2.5.1"
   }
 }


### PR DESCRIPTION
JSHint 2.5 was like a major release and came with lots of improvements and aggravation.

The most important improvement is dropping the `smarttabs` option therewith the absence of the annoying errors regarding »mixed tabs and spaces« within doc block comments like the following:

``` javascript
/**
 * The jQuery object or a jQuery set containing on or more DOM elements.
 * @typedef {Object} jQuery
 */
```

There for local and latest JSHint is showing no errors while the JSHint report of plato is showing me errors regarding those »mixed tabs and spaces«.

I updated my local plato installation to JSHint 2.5.1 and it’s working like a charm :kissing_heart:
