### PR TITLE
Fixes #97 - empty base path when scanning folder

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -9,7 +9,8 @@ var Logger = require('./logger');
 var log = new Logger(Logger.WARNING);
 
 exports.findCommonBase = function(files) {
-  if (!files || files.length === 1) return '';
+  if (!files) return '';
+  if (files.length === 1) return (/(\\|\/)$/.test(files[0])) ? files[0] : '';
   var first = files[0];
   var prefixlen = first.length;
   files.forEach(function(file){


### PR DESCRIPTION
Fixes #97 

When scanning folder, `files` will have single entry with path to that folder. So when `files.length === 1` and file name ends with directory separator, we'll return that name instead of empty string.
