### PR TITLE
Fix an issue when clicking on a graph's first item

### DIFF
--- a/lib/assets/scripts/plato-overview.js
+++ b/lib/assets/scripts/plato-overview.js
@@ -125,7 +125,7 @@ $(function(){
       // If the i is not set, we jump to the last file in the list. This
       // preserves a behavior from Morris v1. I expect Plato V1 to be deprecated
       // and this hack is mearly to preserve the casper tests.
-      if (!i || isNaN(i)) { i = __report.reports.length - 1; }
+      if (i == null || isNaN(i)) { i = __report.reports.length - 1; }
       document.location = __report.reports[i].info.link;
     }
 


### PR DESCRIPTION
Clicking on the first chart is index=0, but the falsey check caused it  
to go to the default behaviour, which is to assume the user clicked on  
the last item in the graph.

An alternative for this would be to have the default behaviour set i=0
rather than i=length - 1.
