### PR TITLE
Only parse history file when one exists

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -34,13 +34,17 @@ exports.formatJSON = function (report) {
 
 exports.readJSON = function (file, options) {
   if (options.q) log.level = Logger.ERROR;
-  var result;
-  log.debug('Parsing JSON from file %s', file);
-  try {
-    var src = fs.readFileSync(file);
-    result = JSON.parse(src);
-  } catch(e) {
-    log.warning('Could not parse JSON from file %s', file);
+  var result = {};
+  if (fs.existsSync(file)) {
+    log.debug('Parsing JSON from file %s', file);
+    try {
+      var src = fs.readFileSync(file);
+      result = JSON.parse(src);
+    } catch(e) {
+      log.warning('Could not parse JSON from file %s', file);
+    }
+  } else {
+    log.info('Not parsing missing file "%s"', file);
   }
   return result;
 };


### PR DESCRIPTION
This PR aims to squelch the console warnings when tring to read a
history file that does not exist. First a check is made to see if the
file exists and only if it does will an attempt at parsing the file be
made.

Fixes #42
