### PR TITLE
Change Linter to CLIEngine to use plugins on ESLint

### DIFF
--- a/lib/reporters/eslint/index.js
+++ b/lib/reporters/eslint/index.js
@@ -35,9 +35,12 @@ function lint(source, config) {
 
   // Remove potential Unicode BOM.
   source = source.replace(/^\uFEFF/, "");
-
-  var messages = ESLINT.linter.verify(source, config);
-  results = results.concat(messages);
+  
+  var cli = new ESLINT.CLIEngine();
+  var messages = cli.executeOnText(source);
+  
+  if(messages && messages.results && messages.results.length && messages.results[0].messages)
+    results = results.concat(messages.results[0].messages);
 
   return {
     results : results,


### PR DESCRIPTION
Actually, Plato uses linter verify as you can see below:
https://github.com/es-analysis/plato/blob/master/lib/reporters/eslint/index.js#L39

But using linter on this way, eslint plugins doesn't work. ESLint team recommends use CLIEngine instead of Linter Verify (https://github.com/eslint/eslint/issues/4119#issuecomment-150065270). 

Could you please validate this PR and if it's OK procceds with merge on master branch?

Thank you!
