### PR TITLE
fix out of memory error

### DIFF
--- a/lib/reporters/jshint/index.js
+++ b/lib/reporters/jshint/index.js
@@ -3,10 +3,10 @@
 var JSHINT = require("jshint").JSHINT;
 var jsHintCli = require("jshint/src/cli.js");
 
-exports.process = function (source, options/*, reportInfo */) {
+exports.process = function (source, options , reportInfo) {
   if (options == null || Object.getOwnPropertyNames(options).length === 0) {
     options = { options : {}, globals : {}};
-    var jsHintOptions = jsHintCli.getConfig(source);
+    var jsHintOptions = jsHintCli.getConfig(reportInfo.file);
     delete jsHintOptions.dirname;
     if (jsHintOptions != null && Object.getOwnPropertyNames(jsHintOptions).length > 0) {
       if (jsHintOptions.globals) {

--- a/test/fixtures/.jshintrc
+++ b/test/fixtures/.jshintrc
@@ -14,8 +14,7 @@
   "unused": true,
   "boss": true,
   "eqnull": true,
-  "node": true,
-  "es5": true
+  "node": true
 }
 
 /* foo */

--- a/test/issues/issue_16_test.js
+++ b/test/issues/issue_16_test.js
@@ -27,8 +27,10 @@ exports['issue_16'] = {
     var file = "test/fixtures/issue_16.js",
         source = fs.readFileSync(file).toString().trim(),
         config = {},
-        globals = [],
-        report = linter.process(source, config, globals);
+        reportInfo = {
+          file: file
+        },
+        report = linter.process(source, config, reportInfo);
 
     test.equal(report.messages.length, 0, "Report returned with messages");
     test.done();


### PR DESCRIPTION
fixes #160 

The `jsHintCli.getConfig()` function takes a files _path_ but was getting passed its _contents_

Fixed the unit test for the new signature of the jshint `process` export.
`issue_16_test` was also written when it would get 0 messages, but there was one about `es6: true` in the `.jshintrc` that jshint added in v2 and above, so i removed `es6: true`
