### PR TITLE
fix unparsable templates

### DIFF
--- a/lib/templates/display.html
+++ b/lib/templates/display.html
@@ -15,11 +15,11 @@
     var __options = <%= JSON.stringify(options) %>
   </script>
 
-  <link href="assets/css/vendor/bootstrap.css" rel="stylesheet">
-  <link href="assets/css/vendor/font-awesome.css" rel="stylesheet">
-  <link href="assets/css/vendor/morris.css" rel="stylesheet">
-  <link href="assets/css/plato.css" rel="stylesheet">
-  <link href="assets/css/plato-display.css" rel="stylesheet">
+  <link href="assets/css/vendor/bootstrap.css" rel="stylesheet"/>
+  <link href="assets/css/vendor/font-awesome.css" rel="stylesheet"/>
+  <link href="assets/css/vendor/morris.css" rel="stylesheet"/>
+  <link href="assets/css/plato.css" rel="stylesheet"/>
+  <link href="assets/css/plato-display.css" rel="stylesheet"/>
 </head>
 
 <body>

--- a/lib/templates/file.html
+++ b/lib/templates/file.html
@@ -12,12 +12,12 @@
   <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
   <![endif]-->
 
-  <link href="../../assets/css/vendor/morris.css" rel="stylesheet">
-  <link href="../../assets/css/vendor/bootstrap.css" rel="stylesheet">
-  <link href="../../assets/css/vendor/font-awesome.css" rel="stylesheet">
-  <link href="../../assets/css/vendor/codemirror.css" rel="stylesheet">
-  <link href="../../assets/css/plato.css" rel="stylesheet">
-  <link href="../../assets/css/plato-file.css" rel="stylesheet">
+  <link href="../../assets/css/vendor/morris.css" rel="stylesheet"/>
+  <link href="../../assets/css/vendor/bootstrap.css" rel="stylesheet"/>
+  <link href="../../assets/css/vendor/font-awesome.css" rel="stylesheet"/>
+  <link href="../../assets/css/vendor/codemirror.css" rel="stylesheet"/>
+  <link href="../../assets/css/plato.css" rel="stylesheet"/>
+  <link href="../../assets/css/plato-file.css" rel="stylesheet"/>
 
 </head>
 

--- a/lib/templates/overview.html
+++ b/lib/templates/overview.html
@@ -16,11 +16,11 @@
     var __options = <%= JSON.stringify(options) %>
   </script>
 
-  <link href="assets/css/vendor/bootstrap.css" rel="stylesheet">
-  <link href="assets/css/vendor/font-awesome.css" rel="stylesheet">
-  <link href="assets/css/vendor/morris.css" rel="stylesheet">
-  <link href="assets/css/plato.css" rel="stylesheet">
-  <link href="assets/css/plato-overview.css" rel="stylesheet">
+  <link href="assets/css/vendor/bootstrap.css" rel="stylesheet"/>
+  <link href="assets/css/vendor/font-awesome.css" rel="stylesheet"/>
+  <link href="assets/css/vendor/morris.css" rel="stylesheet"/>
+  <link href="assets/css/plato.css" rel="stylesheet"/>
+  <link href="assets/css/plato-overview.css" rel="stylesheet"/>
 </head>
 
 <body>


### PR DESCRIPTION
The element type "link" must be terminated by the matching end-tag "</link>"