### PR TITLE
fix problem of  not loading jshintrc file when not supplied options.

### DIFF
--- a/lib/reporters/jshint/index.js
+++ b/lib/reporters/jshint/index.js
@@ -3,10 +3,10 @@
 var JSHINT = require("jshint").JSHINT;
 var jsHintCli = require("jshint/src/cli.js");
 
-exports.process = function (source, options/*, reportInfo */) {
+exports.process = function (source, options, reportInfo) {
   if (options == null || Object.getOwnPropertyNames(options).length === 0) {
     options = { options : {}, globals : {}};
-    var jsHintOptions = jsHintCli.getConfig(source);
+    var jsHintOptions = jsHintCli.getConfig(reportInfo.file);
     delete jsHintOptions.dirname;
     if (jsHintOptions != null && Object.getOwnPropertyNames(jsHintOptions).length > 0) {
       if (jsHintOptions.globals) {

--- a/test/issues/issue_16_test.js
+++ b/test/issues/issue_16_test.js
@@ -26,9 +26,16 @@ exports['issue_16'] = {
 
     var file = "test/fixtures/issue_16.js",
         source = fs.readFileSync(file).toString().trim(),
-        config = {},
-        globals = [],
-        report = linter.process(source, config, globals);
+        options = {},
+        report = {
+          info : {
+            file : '',
+            fileShort : '',
+            fileSafe : '',
+            link : ''
+          }
+        };
+        report = linter.process(source, options, report.info);
 
     test.equal(report.messages.length, 0, "Report returned with messages");
     test.done();

--- a/test/plato_test.js
+++ b/test/plato_test.js
@@ -127,7 +127,7 @@ exports['plato'] = {
 
     plato.inspect(files, null, {}, function(reports) {
       var overview = plato.getOverviewReport(reports);
-      test.ok(overview.summary.total.jshint === 2, 'Should contain total jshint issues');
+      test.ok(overview.summary.total.jshint === 4, 'Should contain total jshint issues');
       test.done();
     });
   }


### PR DESCRIPTION
I fix problem of loading jshintsrc file in plato.inspect() method.

I want to use plato in gulp.

```
gulp.task('plato', function() {
  var src = [......];
  var output = './report';
  var callback = function(report) {
    //....
  };
  plato.inspect(src, output, {}, callback);
});
```

but  this code ignore jshintrc configuration.
I hope that it look '.jshintrc' file.
so that it shold load reportInfo.file in joshing.process().
I try fix it.
