### PR TITLE
updated dependencies

### DIFF
--- a/lib/reporters/complexity/index.js
+++ b/lib/reporters/complexity/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var escomplex = require('escomplex-js'),
+var escomplex = require('escomplex'),
     _         = require('lodash');
 
 exports.process = function(source, options, reportInfo) {
@@ -8,7 +8,7 @@ exports.process = function(source, options, reportInfo) {
   // Make the short filename easily accessible
   report.module = reportInfo.fileShort;
 
-  // Munge the new `escomplex-js` format to match the older format of
+  // Munge the new `escomplex` format to match the older format of
   // `complexity-report`
   report.aggregate.complexity = {
     cyclomatic : report.aggregate.cyclomatic,

--- a/package.json
+++ b/package.json
@@ -1,8 +1,9 @@
 {
   "name": "plato",
   "description": "JavaScript source analysis and visualizer",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "homepage": "https://github.com/es-analysis/plato",
+  "license": "MIT",
   "author": {
     "name": "Jarrod Overson",
     "email": "jsoverson@gmail.com",
@@ -30,12 +31,12 @@
     "test": "grunt test"
   },
   "devDependencies": {
-    "grunt": "~0.4.1",
+    "grunt": "~1.0.1",
     "grunt-casper": "~0.4.0",
-    "grunt-contrib-jshint": "~0.10",
-    "grunt-contrib-nodeunit": "^0.4.1",
-    "grunt-contrib-uglify": "~0.2.0",
-    "grunt-contrib-watch": "~0.6.1"
+    "grunt-contrib-jshint": "~1.0.0",
+    "grunt-contrib-nodeunit": "~1.0.0",
+    "grunt-contrib-uglify": "~1.0.1",
+    "grunt-contrib-watch": "~1.0.0"
   },
   "keywords": [
     "halstead",
@@ -47,13 +48,13 @@
     "analyze"
   ],
   "dependencies": {
-    "escomplex-js": "~1.2.0",
-    "fs-extra": "^0.3.2",
-    "glob": "~4.4.1",
-    "jshint": "~2.6.3",
-    "lodash": "^3.3.1",
-    "posix-getopt": "~1.1.0",
-    "complexity-report": "~0.10.3",
-    "eslint": "^1.5.1"
+    "escomplex": "2.0.0-alpha",
+    "fs-extra": "~0.30.0",
+    "glob": "~7.0.5",
+    "jshint": "~2.9.2",
+    "lodash": "~4.13.1",
+    "posix-getopt": "~1.2.0",
+    "complexity-report": "2.0.0-alpha",
+    "eslint": "~3.0.1"
   }
 }


### PR DESCRIPTION
Plato now supports ES6!

For **eslint**, make sure the following configuration is part of the _.eslintrc_ file:

`"parser": "esprima",
    "parserOptions": {
        "ecmaVersion": 6
    }`