### PR TITLE
Full ES6+ support via typhonjs-escomplex

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
-tmp
-node_module
-node_modules
 .idea
+.DS_Store
+npm-debug.log
+node_modules
 *.sass-cache
 tmp/
 reports/

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -94,7 +94,7 @@ module.exports = function(grunt) {
           '-q',
           '-dtmp',
           '-ttest report',
-          'test/fixtures/a.js','test/fixtures/b.js','test/fixtures/empty.js'
+          'test/fixtures/a.js','test/fixtures/b.js','test/fixtures/c-es6.js','test/fixtures/d-es6.js','test/fixtures/empty.js'
         ]
       },
       function(err, result, code){

--- a/lib/assets/scripts/plato-file.js
+++ b/lib/assets/scripts/plato-file.js
@@ -37,7 +37,6 @@ $(function(){
 
   var popovers = cm.operation(function(){
     var queuedPopovers = [];
-//    __report.complexity.functions.forEach(function(fn,i){
     __report.complexity.methods.forEach(function(fn,i){
       byComplexity.push({
         label : fn.name,
@@ -45,7 +44,6 @@ $(function(){
       });
       bySloc.push({
         label : fn.name,
-//        value : fn.complexity.sloc.physical,
         value : fn.sloc.physical,
         formatter: function (x) { return x + " lines"; }
       });

--- a/lib/assets/scripts/plato-file.js
+++ b/lib/assets/scripts/plato-file.js
@@ -37,19 +37,21 @@ $(function(){
 
   var popovers = cm.operation(function(){
     var queuedPopovers = [];
-    __report.complexity.functions.forEach(function(fn,i){
+//    __report.complexity.functions.forEach(function(fn,i){
+    __report.complexity.methods.forEach(function(fn,i){
       byComplexity.push({
         label : fn.name,
-        value : fn.complexity.cyclomatic
+        value : fn.cyclomatic
       });
       bySloc.push({
         label : fn.name,
-        value : fn.complexity.sloc.physical,
+//        value : fn.complexity.sloc.physical,
+        value : fn.sloc.physical,
         formatter: function (x) { return x + " lines"; }
       });
 
       var name = fn.name === '<anonymous>' ? 'function\\s*\\([^)]*\\)' : fn.name;
-      var line = fn.line - 1;
+      var line = fn.lineStart - 1;
       var className = 'plato-mark-fn-' + i;
       var gutter = {
         gutterId : 'plato-gutter-complexity',
@@ -71,7 +73,7 @@ $(function(){
     var origScroll = [window.pageXOffset,window.pageYOffset];
     window.location.hash = '#plato-mark-fn-' + i;
     window.scrollTo(origScroll[0],origScroll[1]);
-    var line = __report.complexity.functions[i].line;
+    var line = __report.complexity.methods[i].lineStart;
     var coords = cm.charCoords({line : line, ch : 0});
     $('body,html').animate({scrollTop : coords.top -50},250);
   };

--- a/lib/assets/scripts/plato-overview.js
+++ b/lib/assets/scripts/plato-overview.js
@@ -100,19 +100,15 @@ $(function(){
     reports.forEach(function(report){
 
       // @todo shouldn't need this, 'auto [num]' doesn't seem to work : https://github.com/oesmith/morris.js/issues/201
-//      sloc.ymax = Math.max(sloc.ymax, report.complexity.aggregate.complexity.sloc.physical);
-//      bugs.ymax = Math.max(bugs.ymax, report.complexity.aggregate.complexity.halstead.bugs.toFixed(2));
       sloc.ymax = Math.max(sloc.ymax, report.complexity.aggregate.sloc.physical);
       bugs.ymax = Math.max(bugs.ymax, report.complexity.aggregate.halstead.bugs.toFixed(2));
 
 
       sloc.data.push({
-//        value : report.complexity.aggregate.complexity.sloc.physical,
         value : report.complexity.aggregate.sloc.physical,
         label : report.info.fileShort
       });
       bugs.data.push({
-//        value : report.complexity.aggregate.complexity.halstead.bugs.toFixed(2),
         value : report.complexity.aggregate.halstead.bugs.toFixed(2),
         label : report.info.fileShort
       });

--- a/lib/assets/scripts/plato-overview.js
+++ b/lib/assets/scripts/plato-overview.js
@@ -100,16 +100,20 @@ $(function(){
     reports.forEach(function(report){
 
       // @todo shouldn't need this, 'auto [num]' doesn't seem to work : https://github.com/oesmith/morris.js/issues/201
-      sloc.ymax = Math.max(sloc.ymax, report.complexity.aggregate.complexity.sloc.physical);
-      bugs.ymax = Math.max(bugs.ymax, report.complexity.aggregate.complexity.halstead.bugs.toFixed(2));
+//      sloc.ymax = Math.max(sloc.ymax, report.complexity.aggregate.complexity.sloc.physical);
+//      bugs.ymax = Math.max(bugs.ymax, report.complexity.aggregate.complexity.halstead.bugs.toFixed(2));
+      sloc.ymax = Math.max(sloc.ymax, report.complexity.aggregate.sloc.physical);
+      bugs.ymax = Math.max(bugs.ymax, report.complexity.aggregate.halstead.bugs.toFixed(2));
 
 
       sloc.data.push({
-        value : report.complexity.aggregate.complexity.sloc.physical,
+//        value : report.complexity.aggregate.complexity.sloc.physical,
+        value : report.complexity.aggregate.sloc.physical,
         label : report.info.fileShort
       });
       bugs.data.push({
-        value : report.complexity.aggregate.complexity.halstead.bugs.toFixed(2),
+//        value : report.complexity.aggregate.complexity.halstead.bugs.toFixed(2),
+        value : report.complexity.aggregate.halstead.bugs.toFixed(2),
         label : report.info.fileShort
       });
       maintainability.data.push({

--- a/lib/assets/scripts/plato-overview.js
+++ b/lib/assets/scripts/plato-overview.js
@@ -100,16 +100,16 @@ $(function(){
     reports.forEach(function(report){
 
       // @todo shouldn't need this, 'auto [num]' doesn't seem to work : https://github.com/oesmith/morris.js/issues/201
-      sloc.ymax = Math.max(sloc.ymax, report.complexity.aggregate.sloc.physical);
-      bugs.ymax = Math.max(bugs.ymax, report.complexity.aggregate.halstead.bugs.toFixed(2));
+      sloc.ymax = Math.max(sloc.ymax, report.complexity.methodAggregate.sloc.physical);
+      bugs.ymax = Math.max(bugs.ymax, report.complexity.methodAggregate.halstead.bugs.toFixed(2));
 
 
       sloc.data.push({
-        value : report.complexity.aggregate.sloc.physical,
+        value : report.complexity.methodAggregate.sloc.physical,
         label : report.info.fileShort
       });
       bugs.data.push({
-        value : report.complexity.aggregate.halstead.bugs.toFixed(2),
+        value : report.complexity.methodAggregate.halstead.bugs.toFixed(2),
         label : report.info.fileShort
       });
       maintainability.data.push({

--- a/lib/models/FileHistory.js
+++ b/lib/models/FileHistory.js
@@ -16,11 +16,6 @@ FileHistory.prototype.addReport = function(report, date) {
   date = date || report.date || new Date().toUTCString();
   this.push({
     date : date,
-//    sloc : report.complexity.aggregate.complexity.sloc.physical,
-//    lloc : report.complexity.aggregate.complexity.sloc.logical,
-//    functions : report.complexity.functions.length,
-//    deliveredBugs : report.complexity.aggregate.complexity.halstead.bugs,
-//    difficulty: report.complexity.aggregate.complexity.halstead.difficulty,
     sloc : report.complexity.aggregate.sloc.physical,
     lloc : report.complexity.aggregate.sloc.logical,
     functions : report.complexity.methods.length,

--- a/lib/models/FileHistory.js
+++ b/lib/models/FileHistory.js
@@ -16,13 +16,18 @@ FileHistory.prototype.addReport = function(report, date) {
   date = date || report.date || new Date().toUTCString();
   this.push({
     date : date,
-    sloc : report.complexity.aggregate.complexity.sloc.physical,
-    lloc : report.complexity.aggregate.complexity.sloc.logical,
-    functions : report.complexity.functions.length,
-    deliveredBugs : report.complexity.aggregate.complexity.halstead.bugs,
+//    sloc : report.complexity.aggregate.complexity.sloc.physical,
+//    lloc : report.complexity.aggregate.complexity.sloc.logical,
+//    functions : report.complexity.functions.length,
+//    deliveredBugs : report.complexity.aggregate.complexity.halstead.bugs,
+//    difficulty: report.complexity.aggregate.complexity.halstead.difficulty,
+    sloc : report.complexity.aggregate.sloc.physical,
+    lloc : report.complexity.aggregate.sloc.logical,
+    functions : report.complexity.methods.length,
+    deliveredBugs : report.complexity.aggregate.halstead.bugs,
+    difficulty: report.complexity.aggregate.halstead.difficulty,
     maintainability: report.complexity.maintainability,
-    lintErrors : (report.jshint && report.jshint.messages.length) || [],
-    difficulty: report.complexity.aggregate.complexity.halstead.difficulty
+    lintErrors : (report.jshint && report.jshint.messages.length) || []
   });
   return this;
 };

--- a/lib/models/FileHistory.js
+++ b/lib/models/FileHistory.js
@@ -16,11 +16,11 @@ FileHistory.prototype.addReport = function(report, date) {
   date = date || report.date || new Date().toUTCString();
   this.push({
     date : date,
-    sloc : report.complexity.aggregate.sloc.physical,
-    lloc : report.complexity.aggregate.sloc.logical,
+    sloc : report.complexity.methodAggregate.sloc.physical,
+    lloc : report.complexity.methodAggregate.sloc.logical,
     functions : report.complexity.methods.length,
-    deliveredBugs : report.complexity.aggregate.halstead.bugs,
-    difficulty: report.complexity.aggregate.halstead.difficulty,
+    deliveredBugs : report.complexity.methodAggregate.halstead.bugs,
+    difficulty: report.complexity.methodAggregate.halstead.difficulty,
     maintainability: report.complexity.maintainability,
     lintErrors : (report.jshint && report.jshint.messages.length) || []
   });

--- a/lib/plato.js
+++ b/lib/plato.js
@@ -51,6 +51,7 @@ exports.inspect = function(files, outputDir, options, done) {
 
   var flags = {
     complexity : {
+      commonjs : true,
       logicalor : true,
       switchcase : true,
       forin : false,
@@ -184,18 +185,16 @@ exports.getOverviewReport = function (reports) {
     total : {
       jshint: 0,
       sloc : 0,
-      maintainability : 0,
+      maintainability : 0
     },
     average : {
       sloc : 0,
-      maintainability : 0,
+      maintainability : 0
     }
   };
 
   reports.forEach(function(report) {
     // clone objects so we don't have to worry about side effects
-//    summary.total.sloc += report.complexity.aggregate.complexity.sloc.physical;
-//    summary.total.maintainability += report.complexity.maintainability;
     summary.total.sloc += report.complexity.aggregate.sloc.physical;
     summary.total.maintainability += report.complexity.maintainability;
 

--- a/lib/plato.js
+++ b/lib/plato.js
@@ -194,7 +194,9 @@ exports.getOverviewReport = function (reports) {
 
   reports.forEach(function(report) {
     // clone objects so we don't have to worry about side effects
-    summary.total.sloc += report.complexity.aggregate.complexity.sloc.physical;
+//    summary.total.sloc += report.complexity.aggregate.complexity.sloc.physical;
+//    summary.total.maintainability += report.complexity.maintainability;
+    summary.total.sloc += report.complexity.aggregate.sloc.physical;
     summary.total.maintainability += report.complexity.maintainability;
 
     var aggregate = _.cloneDeep(report.complexity.aggregate);

--- a/lib/plato.js
+++ b/lib/plato.js
@@ -195,10 +195,10 @@ exports.getOverviewReport = function (reports) {
 
   reports.forEach(function(report) {
     // clone objects so we don't have to worry about side effects
-    summary.total.sloc += report.complexity.aggregate.sloc.physical;
+    summary.total.sloc += report.complexity.methodAggregate.sloc.physical;
     summary.total.maintainability += report.complexity.maintainability;
 
-    var aggregate = _.cloneDeep(report.complexity.aggregate);
+    var methodAggregate = _.cloneDeep(report.complexity.methodAggregate);
     var reportItem = {};
     reportItem.info = report.info;
     if (report.jshint) {
@@ -209,7 +209,7 @@ exports.getOverviewReport = function (reports) {
     }
     if (report.complexity) {
       reportItem.complexity = {
-        aggregate : aggregate,
+        methodAggregate : methodAggregate,
         module : report.complexity.module,
         module_safe : report.complexity.module_safe,
         maintainability : _.cloneDeep(report.complexity.maintainability)

--- a/lib/reporters/complexity/index.js
+++ b/lib/reporters/complexity/index.js
@@ -1,28 +1,21 @@
 'use strict';
 
-var escomplex = require('escomplex'),
-    _         = require('lodash');
+var escomplex = require('typhonjs-escomplex'),
+  _         = require('lodash');
 
 exports.process = function(source, options, reportInfo) {
-  var report = escomplex.analyse(source, options);
+
+  var report = escomplex.analyze(source, options);
   // Make the short filename easily accessible
   report.module = reportInfo.fileShort;
 
-  // Munge the new `escomplex` format to match the older format of
-  // `complexity-report`
-  report.aggregate.complexity = {
-    cyclomatic : report.aggregate.cyclomatic,
-    sloc       : report.aggregate.sloc,
-    halstead   : report.aggregate.halstead
-  };
-
-  if (_.isArray(report.functions)) {
-    _.each(report.functions, function (func) {
-        func.complexity = {
-            cyclomatic : func.cyclomatic,
-            sloc       : func.sloc,
-            halstead   : func.halstead
-        };
+  // `typhonjs-escomplex` stores class methods inside `classes` entries. For now this is a hack to add class methods
+  // to the end of module methods. Plato needs to be updated to support classes.
+  if (_.isArray(report.methods) && _.isArray(report.classes)) {
+    _.each(report.classes, function (clazz) {
+      _.each(clazz.methods, function (method) {
+        report.methods.push(method);
+      });
     });
   }
 

--- a/lib/reporters/complexity/index.js
+++ b/lib/reporters/complexity/index.js
@@ -1,11 +1,11 @@
 'use strict';
 
 var escomplex = require('typhonjs-escomplex'),
-  _         = require('lodash');
+    _         = require('lodash');
 
 exports.process = function(source, options, reportInfo) {
 
-  var report = escomplex.analyze(source, options);
+  var report = escomplex.analyzeModule(source, options);
   // Make the short filename easily accessible
   report.module = reportInfo.fileShort;
 

--- a/lib/reporters/jshint/index.js
+++ b/lib/reporters/jshint/index.js
@@ -3,10 +3,14 @@
 var JSHINT = require("jshint").JSHINT;
 var jsHintCli = require("jshint/src/cli.js");
 
+// Provides a regexp to test for ES6 / ES Modules. If the pass tests then esversion is set to 6 if not already specified.
+var esmRegex = /(^\s*|[}\);\n]\s*)(import\s*(['"]|(\*\s+as\s+)?[^"'\(\)\n;]+\s*from\s*['"]|\{)|export\s+\*\s+from\s+["']|export\s* (\{|default|function|class|var|const|let|async\s+function))/;
+
 exports.process = function (source, options/*, reportInfo */) {
   if (options == null || Object.getOwnPropertyNames(options).length === 0) {
     options = { options : {}, globals : {}};
     var jsHintOptions = jsHintCli.getConfig(source);
+
     delete jsHintOptions.dirname;
     if (jsHintOptions != null && Object.getOwnPropertyNames(jsHintOptions).length > 0) {
       if (jsHintOptions.globals) {
@@ -17,9 +21,22 @@ exports.process = function (source, options/*, reportInfo */) {
     }
   }
 
+  // Detect if source is an ES Module.
+  if (esmRegex.test(source)) {
+    // Make sure `options.options` is defined
+    if (typeof options.options !== 'object') {
+      options.options = {};
+    }
+
+    // If esversion is not already specified then set `esversion` to 6.
+    if (typeof options.options.esversion !== 'number') {
+      options.options.esversion = 6;
+    }
+  }
+
   var results = lint(source, options.options, options.globals);
-  var report = generateReport(results);
-  return report;
+
+  return generateReport(results);
 };
 
 function generateReport(data) {

--- a/lib/templates/display.html
+++ b/lib/templates/display.html
@@ -65,9 +65,9 @@
             <div class="reportBlock locList">
                 <h2 class="reportTitle">Largest Files</h2>
                 <ul class="list-unstyled">
-<% _.each(_.take(_.sortBy(report.reports, function (report) { return -1 * report.complexity.aggregate.complexity.sloc.physical }), 5), function(report, i) { %>
+<% _.each(_.take(_.sortBy(report.reports, function (report) { return -1 * report.complexity.aggregate.sloc.physical }), 5), function(report, i) { %>
                     <li>
-                        <strong><%= report.complexity.aggregate.complexity.sloc.physical %> lines</strong>
+                        <strong><%= report.complexity.aggregate.sloc.physical %> lines</strong>
                         <small><%= report.info.fileShort %></small>
                     </li>
 <% }); %>

--- a/lib/templates/display.html
+++ b/lib/templates/display.html
@@ -65,9 +65,9 @@
             <div class="reportBlock locList">
                 <h2 class="reportTitle">Largest Files</h2>
                 <ul class="list-unstyled">
-<% _.each(_.take(_.sortBy(report.reports, function (report) { return -1 * report.complexity.aggregate.sloc.physical }), 5), function(report, i) { %>
+<% _.each(_.take(_.sortBy(report.reports, function (report) { return -1 * report.complexity.methodAggregate.sloc.physical }), 5), function(report, i) { %>
                     <li>
-                        <strong><%= report.complexity.aggregate.sloc.physical %> lines</strong>
+                        <strong><%= report.complexity.methodAggregate.sloc.physical %> lines</strong>
                         <small><%= report.info.fileShort %></small>
                     </li>
 <% }); %>

--- a/lib/templates/file.html
+++ b/lib/templates/file.html
@@ -48,7 +48,7 @@
     </div>
     <div class="col-md-6">
       <h2 class="header">Lines of code <i class="icon icon-info-sign" rel="popover" data-placement="top" data-trigger="hover" data-content="Source Lines of Code / Logical Lines of Code" data-original-title="SLOC/LSLOC" data-container="body"></i></h2>
-      <p class="stat"><%= report.complexity.aggregate.complexity.sloc.physical %></p>
+      <p class="stat"><%= report.complexity.aggregate.sloc.physical %></p>
     </div>
   </div>
   <div class="row historical">
@@ -62,11 +62,11 @@
   <div class="row">
     <div class="col-md-6">
       <h2 class="header">Difficulty  <a href="http://en.wikipedia.org/wiki/Halstead_complexity_measures"><i class="icon icon-info-sign" rel="popover" data-placement="top" data-trigger="hover" data-content="The difficulty measure is related to the difficulty of the program to write or understand." data-original-title="Difficulty" data-container="body"></i></a></h2>
-      <p class="stat"><%= report.complexity.aggregate.complexity.halstead.difficulty.toFixed(2) %></p>
+      <p class="stat"><%= report.complexity.aggregate.halstead.difficulty.toFixed(2) %></p>
     </div>
     <div class="col-md-6">
       <h2 class="header">Estimated Errors  <a href="http://en.wikipedia.org/wiki/Halstead_complexity_measures"><i class="icon icon-info-sign" rel="popover" data-placement="top" data-trigger="hover" data-content="Halstead's delivered bugs is an estimate for the number of errors in the implementation." data-original-title="Delivered Bugs" data-container="body"></i></a></h2>
-      <p class="stat"><%= report.complexity.aggregate.complexity.halstead.bugs.toFixed(2) %></p>
+      <p class="stat"><%= report.complexity.aggregate.halstead.bugs.toFixed(2) %></p>
     </div>
   </div>
 </div>
@@ -101,10 +101,10 @@
 
 <script type="text/html" id="complexity-popover-template">
   <div class="complexity-notice">
-    Complexity : {{ complexity.cyclomatic }} <br>
-    Length : {{ complexity.halstead.length }} <br>
-    Difficulty : {{ complexity.halstead.difficulty.toFixed(2) }} <br>
-    Est # bugs : {{ complexity.halstead.bugs.toFixed(2) }}<br>
+    Complexity : {{ cyclomatic }} <br>
+    Length : {{ halstead.length }} <br>
+    Difficulty : {{ halstead.difficulty.toFixed(2) }} <br>
+    Est # bugs : {{ halstead.bugs.toFixed(2) }}<br>
   </div>
 </script>
 

--- a/lib/templates/file.html
+++ b/lib/templates/file.html
@@ -48,7 +48,7 @@
     </div>
     <div class="col-md-6">
       <h2 class="header">Lines of code <i class="icon icon-info-sign" rel="popover" data-placement="top" data-trigger="hover" data-content="Source Lines of Code / Logical Lines of Code" data-original-title="SLOC/LSLOC" data-container="body"></i></h2>
-      <p class="stat"><%= report.complexity.aggregate.sloc.physical %></p>
+      <p class="stat"><%= report.complexity.methodAggregate.sloc.physical %></p>
     </div>
   </div>
   <div class="row historical">
@@ -62,11 +62,11 @@
   <div class="row">
     <div class="col-md-6">
       <h2 class="header">Difficulty  <a href="http://en.wikipedia.org/wiki/Halstead_complexity_measures"><i class="icon icon-info-sign" rel="popover" data-placement="top" data-trigger="hover" data-content="The difficulty measure is related to the difficulty of the program to write or understand." data-original-title="Difficulty" data-container="body"></i></a></h2>
-      <p class="stat"><%= report.complexity.aggregate.halstead.difficulty.toFixed(2) %></p>
+      <p class="stat"><%= report.complexity.methodAggregate.halstead.difficulty.toFixed(2) %></p>
     </div>
     <div class="col-md-6">
       <h2 class="header">Estimated Errors  <a href="http://en.wikipedia.org/wiki/Halstead_complexity_measures"><i class="icon icon-info-sign" rel="popover" data-placement="top" data-trigger="hover" data-content="Halstead's delivered bugs is an estimate for the number of errors in the implementation." data-original-title="Delivered Bugs" data-container="body"></i></a></h2>
-      <p class="stat"><%= report.complexity.aggregate.halstead.bugs.toFixed(2) %></p>
+      <p class="stat"><%= report.complexity.methodAggregate.halstead.bugs.toFixed(2) %></p>
     </div>
   </div>
 </div>

--- a/lib/templates/overview.html
+++ b/lib/templates/overview.html
@@ -121,9 +121,9 @@
           <span class="col-md-4 file"><a class="file-link" href="./<%= item.info.link %>"><%= item.info.fileShort %></a></span>
         <span class="col-md-8 file-chart js-file-chart"
               data-lint="<%= item.jshint && item.jshint.messages %>"
-              data-sloc="<%= item.complexity.aggregate.sloc.physical %>"
-              data-bugs="<%= item.complexity.aggregate.halstead.bugs.toFixed(2) %>"
-              data-complexity="<%= item.complexity.aggregate.cyclomatic%>"
+              data-sloc="<%= item.complexity.methodAggregate.sloc.physical %>"
+              data-bugs="<%= item.complexity.methodAggregate.halstead.bugs.toFixed(2) %>"
+              data-complexity="<%= item.complexity.methodAggregate.cyclomatic%>"
           ></span>
         </div>
       </li>

--- a/lib/templates/overview.html
+++ b/lib/templates/overview.html
@@ -121,9 +121,9 @@
           <span class="col-md-4 file"><a class="file-link" href="./<%= item.info.link %>"><%= item.info.fileShort %></a></span>
         <span class="col-md-8 file-chart js-file-chart"
               data-lint="<%= item.jshint && item.jshint.messages %>"
-              data-sloc="<%= item.complexity.aggregate.complexity.sloc.physical %>"
-              data-bugs="<%= item.complexity.aggregate.complexity.halstead.bugs.toFixed(2) %>"
-              data-complexity="<%= item.complexity.aggregate.complexity.cyclomatic%>"
+              data-sloc="<%= item.complexity.aggregate.sloc.physical %>"
+              data-bugs="<%= item.complexity.aggregate.halstead.bugs.toFixed(2) %>"
+              data-complexity="<%= item.complexity.aggregate.cyclomatic%>"
           ></span>
         </div>
       </li>

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "analyze"
   ],
   "dependencies": {
-    "typhonjs-escomplex": "0.0.6",
+    "typhonjs-escomplex": "0.0.7",
     "fs-extra": "~0.30.0",
     "glob": "~7.0.5",
     "jshint": "~2.9.2",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "analyze"
   ],
   "dependencies": {
-    "typhonjs-escomplex": "0.0.7",
+    "typhonjs-escomplex": "0.0.9",
     "fs-extra": "~0.30.0",
     "glob": "~7.0.5",
     "jshint": "~2.9.2",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "analyze"
   ],
   "dependencies": {
-    "typhonjs-escomplex": ">=0.0.6",
+    "typhonjs-escomplex": "0.0.6",
     "fs-extra": "~0.30.0",
     "glob": "~7.0.5",
     "jshint": "~2.9.2",

--- a/package.json
+++ b/package.json
@@ -48,14 +48,12 @@
     "analyze"
   ],
   "dependencies": {
-    "escomplex": "2.0.0-alpha",
+    "typhonjs-escomplex": ">=0.0.6",
     "fs-extra": "~0.30.0",
     "glob": "~7.0.5",
     "jshint": "~2.9.2",
     "lodash": "~4.13.1",
     "posix-getopt": "~1.2.0",
-    "complexity-report": "2.0.0-alpha",
-    "eslint": "~3.0.1",
-    "esprima": "~2.7.2"
+    "eslint": "~3.0.1"
   }
 }

--- a/test/casper-overview.js
+++ b/test/casper-overview.js
@@ -12,7 +12,7 @@ casper.start('./tmp/index.html', function() {
   this.test.assertSelectorHasText('.jumbotron h1', 'test report');
   this.test.assertEvalEquals(function() {
     return document.querySelectorAll('.file-list li').length;
-  }, 2, 'Has appropriate number list items in the file list');
+  }, 4, 'Has appropriate number list items in the file list');
   this.test.assertEval(function() {
     return document.querySelectorAll('.chart').length === document.querySelectorAll('.chart svg').length;
   }, 'Every summary chart has an svg drawn');
@@ -22,7 +22,8 @@ casper.start('./tmp/index.html', function() {
 });
 
 casper.then(function () {
-  this.click('#chart_sloc svg');
+  var chart = this.getElementInfo('#chart_sloc svg');
+  this.mouse.click(chart.x + 1, chart.y + 1);
 });
 
 casper.waitForSelectorTextChange('.jumbotron h1', function() {

--- a/test/fixtures/c-es6.js
+++ b/test/fixtures/c-es6.js
@@ -1,0 +1,21 @@
+
+const a = 1;
+
+class C
+{
+  static classMethodA(arg) {
+    return arg;
+  }
+
+  static classMethodB(arg) {
+    return arg;
+  }
+}
+
+function moduleMethod(arg) {
+  return arg;
+}
+
+const b = moduleMethod(0) + C.classMethodB(1) + C.classMethodA(2);
+
+export default C;

--- a/test/fixtures/d-es6.js
+++ b/test/fixtures/d-es6.js
@@ -1,0 +1,24 @@
+
+const a = 1;
+
+class D
+{
+  static classMethodA(arg) {
+    return arg;
+  }
+
+  static classMethodB(arg) {
+    return arg;
+  }
+}
+
+function moduleMethod(arg) {
+  return arg;
+}
+
+const b = moduleMethod(0) + D.classMethodB(1) + D.classMethodA(2);
+
+let c = b + moduleMethod(0) + D.classMethodA(a) * D.classMethodB(1);
+    c = null;
+
+export default D;

--- a/test/fixtures/model_history.json
+++ b/test/fixtures/model_history.json
@@ -6,140 +6,132 @@
       "link":"files/lib_logger_js/index.html"
    },
    "complexity":{
+     "lineStart":1,
       "aggregate":{
-         "line":1,
-         "complexity":{
-            "sloc":{
-               "physical":22,
-               "logical":10
+         "sloc":{
+            "physical":22,
+            "logical":10
+         },
+         "cyclomatic":2,
+         "halstead":{
+            "operators":{
+               "distinct":8,
+               "total":25,
+               "identifiers":[
+                  "__stripped__"
+               ]
             },
-            "cyclomatic":2,
+            "operands":{
+               "distinct":21,
+               "total":37,
+               "identifiers":[
+                  "__stripped__"
+               ]
+            },
+            "length":62,
+            "vocabulary":29,
+            "difficulty":7.0476190476190474,
+            "volume":301.1948216979095,
+            "effort":2122.70636244241,
+            "bugs":0.10039827389930317,
+            "time":117.92813124680055
+         }
+      },
+      "methods":[
+         {
+            "name":"Logger",
+            "lineStart":5,
+            "sloc":{
+               "physical":3,
+               "logical":1
+            },
+            "cyclomatic":1,
             "halstead":{
                "operators":{
-                  "distinct":8,
-                  "total":25,
+                  "distinct":2,
+                  "total":2,
                   "identifiers":[
                      "__stripped__"
                   ]
                },
                "operands":{
-                  "distinct":21,
-                  "total":37,
+                  "distinct":2,
+                  "total":4,
                   "identifiers":[
                      "__stripped__"
                   ]
                },
-               "length":62,
-               "vocabulary":29,
-               "difficulty":7.0476190476190474,
-               "volume":301.1948216979095,
-               "effort":2122.70636244241,
-               "bugs":0.10039827389930317,
-               "time":117.92813124680055
-            }
-         }
-      },
-      "functions":[
-         {
-            "name":"Logger",
-            "line":5,
-            "complexity":{
-               "sloc":{
-                  "physical":3,
-                  "logical":1
-               },
-               "cyclomatic":1,
-               "halstead":{
-                  "operators":{
-                     "distinct":2,
-                     "total":2,
-                     "identifiers":[
-                        "__stripped__"
-                     ]
-                  },
-                  "operands":{
-                     "distinct":2,
-                     "total":4,
-                     "identifiers":[
-                        "__stripped__"
-                     ]
-                  },
-                  "length":6,
-                  "vocabulary":4,
-                  "difficulty":2,
-                  "volume":12,
-                  "effort":24,
-                  "bugs":0.004,
-                  "time":1.3333333333333333
-               }
+               "length":6,
+               "vocabulary":4,
+               "difficulty":2,
+               "volume":12,
+               "effort":24,
+               "bugs":0.004,
+               "time":1.3333333333333333
             }
          },
          {
             "name":"<anonymous>",
             "line":17,
-            "complexity":{
-               "sloc":{
-                  "physical":6,
-                  "logical":2
+            "sloc":{
+               "physical":6,
+               "logical":2
+            },
+            "cyclomatic":1,
+            "halstead":{
+               "operators":{
+                  "distinct":4,
+                  "total":8,
+                  "identifiers":[
+                     "__stripped__"
+                  ]
                },
-               "cyclomatic":1,
-               "halstead":{
-                  "operators":{
-                     "distinct":4,
-                     "total":8,
-                     "identifiers":[
-                        "__stripped__"
-                     ]
-                  },
-                  "operands":{
-                     "distinct":6,
-                     "total":10,
-                     "identifiers":[
-                        "__stripped__"
-                     ]
-                  },
-                  "length":18,
-                  "vocabulary":10,
-                  "difficulty":3.3333333333333335,
-                  "volume":59.794705707972525,
-                  "effort":199.31568569324176,
-                  "bugs":0.019931568569324175,
-                  "time":11.073093649624543
-               }
+               "operands":{
+                  "distinct":6,
+                  "total":10,
+                  "identifiers":[
+                     "__stripped__"
+                  ]
+               },
+               "length":18,
+               "vocabulary":10,
+               "difficulty":3.3333333333333335,
+               "volume":59.794705707972525,
+               "effort":199.31568569324176,
+               "bugs":0.019931568569324175,
+               "time":11.073093649624543
             }
          },
          {
             "name":"<anonymous>.undefined",
-            "line":19,
-            "complexity":{
-               "sloc":{
-                  "physical":3,
-                  "logical":2
+            "lineStart":19,
+            "sloc":{
+               "physical":3,
+               "logical":2
+            },
+            "cyclomatic":2,
+            "halstead":{
+               "operators":{
+                  "distinct":4,
+                  "total":6,
+                  "identifiers":[
+                     "__stripped__"
+                  ]
                },
-               "cyclomatic":2,
-               "halstead":{
-                  "operators":{
-                     "distinct":4,
-                     "total":6,
-                     "identifiers":[
-                        "__stripped__"
-                     ]
-                  },
-                  "operands":{
-                     "distinct":7,
-                     "total":8,
-                     "identifiers":[
-                        "__stripped__"
-                     ]
-                  },
-                  "length":14,
-                  "vocabulary":11,
-                  "difficulty":2.2857142857142856,
-                  "volume":48.43204266092217,
-                  "effort":110.70181179639353,
-                  "bugs":0.016144014220307392,
-                  "time":6.150100655355196
-               }
+               "operands":{
+                  "distinct":7,
+                  "total":8,
+                  "identifiers":[
+                     "__stripped__"
+                  ]
+               },
+               "length":14,
+               "vocabulary":11,
+               "difficulty":2.2857142857142856,
+               "volume":48.43204266092217,
+               "effort":110.70181179639353,
+               "bugs":0.016144014220307392,
+               "time":6.150100655355196
             }
          }
       ],

--- a/test/fixtures/model_history.json
+++ b/test/fixtures/model_history.json
@@ -7,7 +7,7 @@
    },
    "complexity":{
      "lineStart":1,
-      "aggregate":{
+      "methodAggregate":{
          "sloc":{
             "physical":22,
             "logical":10

--- a/test/model_filehistory_test.js
+++ b/test/model_filehistory_test.js
@@ -32,12 +32,12 @@ exports['FileHistory'] = {
     var newReport = require('./fixtures/model_history.json');
     history.addReport(newReport);
 
-    test.equal(history[0].sloc, newReport.complexity.aggregate.complexity.sloc.physical);
-    test.equal(history[0].lloc, newReport.complexity.aggregate.complexity.sloc.logical);
-    test.equal(history[0].deliveredBugs, newReport.complexity.aggregate.complexity.halstead.bugs);
-    test.equal(history[0].difficulty, newReport.complexity.aggregate.complexity.halstead.difficulty);
+    test.equal(history[0].sloc, newReport.complexity.aggregate.sloc.physical);
+    test.equal(history[0].lloc, newReport.complexity.aggregate.sloc.logical);
+    test.equal(history[0].deliveredBugs, newReport.complexity.aggregate.halstead.bugs);
+    test.equal(history[0].difficulty, newReport.complexity.aggregate.halstead.difficulty);
     test.equal(history[0].maintainability, newReport.complexity.maintainability);
-    test.equal(history[0].functions, newReport.complexity.functions.length);
+    test.equal(history[0].functions, newReport.complexity.methods.length);
     test.equal(history[0].lintErrors, newReport.jshint.messages.length);
     test.done();
   },

--- a/test/model_filehistory_test.js
+++ b/test/model_filehistory_test.js
@@ -40,6 +40,6 @@ exports['FileHistory'] = {
     test.equal(history[0].functions, newReport.complexity.methods.length);
     test.equal(history[0].lintErrors, newReport.jshint.messages.length);
     test.done();
-  },
+  }
 
 };

--- a/test/model_filehistory_test.js
+++ b/test/model_filehistory_test.js
@@ -32,10 +32,10 @@ exports['FileHistory'] = {
     var newReport = require('./fixtures/model_history.json');
     history.addReport(newReport);
 
-    test.equal(history[0].sloc, newReport.complexity.aggregate.sloc.physical);
-    test.equal(history[0].lloc, newReport.complexity.aggregate.sloc.logical);
-    test.equal(history[0].deliveredBugs, newReport.complexity.aggregate.halstead.bugs);
-    test.equal(history[0].difficulty, newReport.complexity.aggregate.halstead.difficulty);
+    test.equal(history[0].sloc, newReport.complexity.methodAggregate.sloc.physical);
+    test.equal(history[0].lloc, newReport.complexity.methodAggregate.sloc.logical);
+    test.equal(history[0].deliveredBugs, newReport.complexity.methodAggregate.halstead.bugs);
+    test.equal(history[0].difficulty, newReport.complexity.methodAggregate.halstead.difficulty);
     test.equal(history[0].maintainability, newReport.complexity.maintainability);
     test.equal(history[0].functions, newReport.complexity.methods.length);
     test.equal(history[0].lintErrors, newReport.jshint.messages.length);

--- a/test/plato_test.js
+++ b/test/plato_test.js
@@ -33,11 +33,13 @@ exports['plato'] = {
     var files = [
       'test/fixtures/a.js',
       'test/fixtures/b.js',
+      'test/fixtures/c-es6.js',
+      'test/fixtures/d-es6.js',
       'test/fixtures/empty.js'
     ];
 
     plato.inspect(files, null, {}, function(reports) {
-      test.equal(reports.length, 2, 'Should not attempt to report on empty files');
+      test.equal(reports.length, 4, 'Should not attempt to report on empty files');
       test.done();
     });
   },
@@ -47,16 +49,18 @@ exports['plato'] = {
     var files = './test/fixtures/*.js';
 
     plato.inspect(files, null, {}, function(reports) {
-      test.equal(reports.length, 5, 'Should properly test against the array produced by the glob');
+      test.equal(reports.length, 7, 'Should properly test against the array produced by the glob');
       test.done();
     });
   },
   'test report structure' : function(test) {
-    test.expect(4);
+    test.expect(8);
 
     var files = [
       'test/fixtures/a.js',
-      'test/fixtures/b.js'
+      'test/fixtures/b.js',
+      'test/fixtures/c-es6.js',
+      'test/fixtures/d-es6.js'
     ];
 
     plato.inspect(files, null, {}, function(reports) {
@@ -71,10 +75,13 @@ exports['plato'] = {
 
     var files = [
       'test/fixtures/a.js',
-      'test/fixtures/b.js'
+      'test/fixtures/b.js',
+      'test/fixtures/c-es6.js',
+      'test/fixtures/d-es6.js'
     ];
 
-    test.expect((files.length * 3) + 1);
+//    test.expect((files.length * 3) + 1);
+    test.expect(7);
 
     plato.inspect(files, null, {}, function(reports) {
       var overview = plato.getOverviewReport(reports);
@@ -94,11 +101,13 @@ exports['plato'] = {
     var files = [
       'test/fixtures/a.js',
       'test/fixtures/b.js',
+      'test/fixtures/c-es6.js',
+      'test/fixtures/d-es6.js',
       'test/fixtures/shebang.js'
     ];
 
     plato.inspect(files, null, {}, function(reports) {
-      test.equal(reports.length, 3, 'Should report on files starting with a shebang');
+      test.equal(reports.length, 5, 'Should report on files starting with a shebang');
       test.done();
     });
   },
@@ -120,14 +129,16 @@ exports['plato'] = {
 
     var files = [
       'test/fixtures/a.js',
-      'test/fixtures/b.js'
+      'test/fixtures/b.js',
+      'test/fixtures/c-es6.js',
+      'test/fixtures/d-es6.js'
     ];
 
     test.expect(1);
 
     plato.inspect(files, null, {}, function(reports) {
       var overview = plato.getOverviewReport(reports);
-      test.ok(overview.summary.total.jshint === 2, 'Should contain total jshint issues');
+      test.ok(overview.summary.total.jshint === 4, 'Should contain total jshint issues');
       test.done();
     });
   }


### PR DESCRIPTION
Greets folks... @jsoverson This PR updates plato to use `typhonjs-escomplex` which is a completely rewritten version of escomplex supporting ES6+ / ES7 / edge complexity reporting. Plato has been updated with mixed ES5 / ES6 tests, automatic detection for ES Modules / ES6 for JSHint options, normalized all of the accessing code and HTML templates removing previous shims for escomplex data. 