### PR TITLE
Might as well take 0.0.12 of typhonjs-escomplex

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "analyze"
   ],
   "dependencies": {
-    "typhonjs-escomplex": "0.0.9",
+    "typhonjs-escomplex": "0.0.11",
     "fs-extra": "~0.30.0",
     "glob": "~7.0.5",
     "jshint": "~2.9.2",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "analyze"
   ],
   "dependencies": {
-    "typhonjs-escomplex": "0.0.11",
+    "typhonjs-escomplex": "0.0.12",
     "fs-extra": "~0.30.0",
     "glob": "~7.0.5",
     "jshint": "~2.9.2",


### PR DESCRIPTION
@jsoverson You might as well take ~~0.0.11~~ 0.0.12 of typhonjs-escomplex before updating the Plato NPM module. I've strengthened / corrected a few Halstead metrics gathered, so accuracy in that regard is up. The old escomplex needed a thorough review. For instance `this` was counted as an operand not as an operator. Member expressions that are computed always added `.` as an operator instead of `[]`, etc. Just some corrections over the old escomplex.

This PR simply bumps typhonjs-escomplex to `0.0.12`. 

It will be several days before I get 0.0.13 out as I'm fully working over how metrics are gathered for class / module aggregates; this isn't exposed by plato per se. If there are any concerns questions let me know. 
