### PR TITLE
Display a friendly message if no files are specified (or when no files match the given pattern)

### DIFF
--- a/lib/plato.js
+++ b/lib/plato.js
@@ -20,6 +20,7 @@ var glob = require('glob');
 
 // local lib
 var util = require('./util'),
+    info = require('./info.js'),
     OverviewHistory = require('./models/OverviewHistory'),
     FileHistory = require('./models/FileHistory'),
     Logger = require('./logger'),
@@ -41,13 +42,22 @@ function unary(fn) { return function(a){ return fn(a);}; }
 
 exports.inspect = function(files, outputDir, options, done) {
 
-	if (!files) {
-	  // at least give me a file man...
-	  return;
-	}
+  if (!files) {
+    // at least give me a file man...
+    console.log('No files found');
+    info.help();
+    return;
+  }
 
   files = files instanceof Array ? files : [files];
   files = _.flatten(files.map(unary(glob.sync)));
+
+  if (!files.length) {
+    // no matching files
+    console.log('No files found');
+    info.help();
+    return;
+  }
 
   var flags = {
     complexity : {

--- a/lib/plato.js
+++ b/lib/plato.js
@@ -20,7 +20,7 @@ var glob = require('glob');
 
 // local lib
 var util = require('./util'),
-    info = require('./info.js'),
+    info = require('./info'),
     OverviewHistory = require('./models/OverviewHistory'),
     FileHistory = require('./models/FileHistory'),
     Logger = require('./logger'),


### PR DESCRIPTION
Currently if files are not specified, Plato exits with a stack trace. This PR intends to print a message saying "No files found" along with the Plato usage help.

Changes (using cli.js as reference):
- imported info.js into plato.js
- print console.log and call info.help() if `files` or `files.length` are falsy

For issue #205

### Before
```
$ bin/plato -d foo
/git/plato/lib/util.js:15
  var lastSlash = files[0].lastIndexOf(path.sep);
                          ^

TypeError: Cannot read property 'lastIndexOf' of undefined
    at Object.exports.findCommonBase (/git/plato/lib/util.js:15:27)
    at Object.exports.inspect (/git/plato/lib/plato.js:87:29)
    at Object.exports.exec (/git/plato/lib/cli.js:53:9)
    at Object.<anonymous> (/git/plato/bin/plato:19:5)
    at Module._compile (module.js:571:32)
    at Object.Module._extensions..js (module.js:580:10)
    at Module.load (module.js:488:32)
    at tryModuleLoad (module.js:447:12)
    at Function.Module._load (module.js:439:3)
    at Module.runMain (module.js:605:10)
```
Same result with `$bin/plato -d foo bar`

### After
```
$ bin/plato -d foo
No files found

Usage : plato [options] file1.js file2.js ... fileN.js
  -h, --help
      Display this help text.
  -q, --quiet
      Reduce output to errors only
  -v, --version
      Print the version.
  -x, --exclude : String
      File exclusion regex
  -d, --dir : String *required*
      The output directory
  -r, --recurse
      Recursively search directories
  -l, --jshint : String
      Specify a jshintrc file for JSHint linting
  -e, --eslint : String
      Specify a eslintrc file for ESLint linting
  -t, --title : String
      Title of the report
  -D, --date : String
      Time to use as the report date (seconds, > 9999999999 assumed to be ms)
  -n, --noempty
      Skips empty lines from line count
```
