### PR TITLE
Remove .js ext requirement

### DIFF
--- a/lib/plato.js
+++ b/lib/plato.js
@@ -95,7 +95,7 @@ exports.inspect = function(files, outputDir, options, done) {
           return path.join(file,innerFile);
         });
         runReports(files);
-      } else if (file.match(/\.js$/)) {
+      } else if (file.match(/(\.js)?$/)) {
         log.info('Reading "%s"', file);
 
         var fileShort = file.replace(commonBasePath, '');


### PR DESCRIPTION
The change makes the `.js` extension optional.
Reason:
- I'd like to analyze the `bin/www` file the Express typically generates
- I'd also like analyze any other `.sh` or other file with `#!/usr/bin/env node` at the top.

In the report, the shell env line-1 is automatically commented out (see attached).
<img width="412" alt="screen shot 2017-06-09 at 3 03 23 pm" src="https://user-images.githubusercontent.com/789684/26990522-d8e6c066-4d24-11e7-9978-ec2211e093a8.png">
